### PR TITLE
cepheus: Inherit basic sepolicy for vendor build

### DIFF
--- a/sepolicy/vendor/hal_audio_default.te
+++ b/sepolicy/vendor/hal_audio_default.te
@@ -1,0 +1,2 @@
+allow hal_audio_default property_socket:sock_file { write };
+allow hal_audio_default init:unix_stream_socket { connectto };

--- a/sepolicy/vendor/hal_health_default.te
+++ b/sepolicy/vendor/hal_health_default.te
@@ -1,0 +1,1 @@
+allow hal_health_default sysfs:file { read open getattr };

--- a/sepolicy/vendor/init.te
+++ b/sepolicy/vendor/init.te
@@ -1,0 +1,3 @@
+allow init firmware_file:filesystem { getattr };
+allow init bt_firmware_file:filesystem { getattr };
+allow init sysfs:file { open write };

--- a/sepolicy/vendor/proc_net.te
+++ b/sepolicy/vendor/proc_net.te
@@ -1,0 +1,1 @@
+allow proc_net proc:filesystem { associate };

--- a/sepolicy/vendor/qti_init_shell.te
+++ b/sepolicy/vendor/qti_init_shell.te
@@ -1,0 +1,4 @@
+allow qti_init_shell sysfs_io_sched_tuneable:file { write };
+allow qti_init_shell sysfs:file { write };
+allow qti_init_shell sysfs_loop:file { write };
+allow qti_init_shell sysfs_devices_block:file { write };

--- a/sepolicy/vendor/rild.te
+++ b/sepolicy/vendor/rild.te
@@ -1,0 +1,1 @@
+allow rild default_prop:file { map };

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -1,0 +1,1 @@
+allow system_server init:binder { call };


### PR DESCRIPTION
Just small commit, maybe you needed to enforce selinux