### PR TITLE
Fix the white screen problem of some Alipay interface

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -36,6 +36,9 @@ ro.surface_flinger.has_wide_color_display=true
 ro.surface_flinger.has_HDR_display=true
 debug.cpurend.vsync=false
 
+# HWUI drawing
+debug.hwui.renderer=skiagl
+
 # Incremental FS
 ro.incremental.enable=1
 


### PR DESCRIPTION
When using Ali-based apps such as Taobao and Alipay, there will be some interface white screen issues, let us fix it.